### PR TITLE
Handle Long type properly when creating user

### DIFF
--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -105,11 +105,13 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
         final Object value = custom.get(key);
         if (value instanceof String) {
           userBuilder.custom(key, (String) value);
+        } else if (value instanceof Long) {
+            userBuilder.custom(key, (Long) value);
         } else if (value instanceof Integer) {
           userBuilder.custom(key, (Integer) value);
         } else if (value instanceof Double) {
           userBuilder.custom(key, (Double) value);
-       } else if (value instanceof Boolean) {
+        } else if (value instanceof Boolean) {
           userBuilder.custom(key, (Boolean) value);
         }
       }


### PR DESCRIPTION
### Requirements

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

### Related issues

Unlike Dart, Java has four integer types: byte, short, int and long. Long integers like a timestamp won't fit int and will be converted to long rather than int. Meaning, when `identify` is called those attributes will be omitted from resulting custom attributes map and won't be sent to Launch Darkly.  

### Describe the solution you've provided

I've added another else-if branch to handle Long type.

### How to test?

```
  import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
  ...

  Future<void> init() async {
    await LaunchdarklyFlutter().init(
      'your_api_key',
      'test_user',
      custom: {
        'timestamp': DateTime.now().toUtc().millisecondsSinceEpoch,
      },
    );
  }
```

I open this PR against the forked `master` first but I can re-target to the original repository.